### PR TITLE
[Feat]: PillManager 세부 구현, PillIController의 identifyPill 응답값 변경

### DIFF
--- a/clients/client-example/src/main/kotlin/org/mediscan/client/example/model/PillIdentificationResponseDto.kt
+++ b/clients/client-example/src/main/kotlin/org/mediscan/client/example/model/PillIdentificationResponseDto.kt
@@ -2,5 +2,5 @@ package org.mediscan.client.example.model;
 
 data class PillIdentificationResponseDto(
         var drugCode: String,
-        var confidence: Double
+        var confidence: Long
 )

--- a/core/core-api/src/main/kotlin/org/mediscan/core/api/controller/v1/PillIController.kt
+++ b/core/core-api/src/main/kotlin/org/mediscan/core/api/controller/v1/PillIController.kt
@@ -13,8 +13,22 @@ class PillIController(
     private var pillService: PillService
 ) {
     @PostMapping("/pill")
-    fun identifyPill(@RequestBody request: PillIdentificationRequestDto): ApiResponse<PillIdentificationResponseDto> {
-        val result =pillService.identifyPill(request.frontImage, request.backImage, request.pillShape, request.frontMarking, request.backMarking)
-        return ApiResponse.success(PillIdentificationResponseDto(result.confidence,result.drugCode))
+    fun identifyPill(@RequestBody request: PillIdentificationRequestDto): ApiResponse<List<PillIdentificationResponseDto>> {
+        val results = pillService.identifyPill(
+            request.frontImage,
+            request.backImage,
+            request.pillShape,
+            request.frontMarking,
+            request.backMarking
+        )
+
+        val responseDtos = results.map { result ->
+            PillIdentificationResponseDto(
+                drugCode = result.drugCode,
+                confidence = result.confidence
+            )
+        }
+
+        return ApiResponse.success(responseDtos)
     }
 }

--- a/core/core-api/src/main/kotlin/org/mediscan/core/api/domain/PillManager.kt
+++ b/core/core-api/src/main/kotlin/org/mediscan/core/api/domain/PillManager.kt
@@ -1,16 +1,29 @@
 package org.mediscan.core.api.domain;
 
+import org.mediscan.client.example.PillIdentificationService
 import org.mediscan.core.api.domain.v1.request.PillDomainIdentificationRequestDto
 import org.mediscan.core.api.domain.v1.response.PillDomainIdentificationResponseDto
 import org.springframework.stereotype.Component
-import org.springframework.web.multipart.MultipartFile
 
 
 @Component
-class PillManager {
-    fun identifyPill(request: PillDomainIdentificationRequestDto): PillDomainIdentificationResponseDto {
+class PillManager(
+    private val pillIdentificationService: PillIdentificationService
+) {
+    fun identifyPill(request: PillDomainIdentificationRequestDto): List<PillDomainIdentificationResponseDto> {
+        val results = pillIdentificationService.identifyPill(
+            request.frontImage,
+            request.backImage,
+            request.pillShape,
+            request.frontMarking,
+            request.backMarking
+        )
 
-        return PillDomainIdentificationResponseDto(0, "Drug Code")
+        return results.map { responseDto ->
+            PillDomainIdentificationResponseDto(
+                drugCode = responseDto.drugCode,
+                confidence = responseDto.confidence
+            )
+        }
     }
-
 }

--- a/core/core-api/src/main/kotlin/org/mediscan/core/api/domain/PillService.kt
+++ b/core/core-api/src/main/kotlin/org/mediscan/core/api/domain/PillService.kt
@@ -10,7 +10,7 @@ class PillService (
     private val pillManager: PillManager
 ){
     fun identifyPill(frontImage: MultipartFile, backImage: MultipartFile,
-                     fillShape: String, frontMarking: String, backMarking: String ): PillDomainIdentificationResponseDto  {
+                     fillShape: String, frontMarking: String, backMarking: String ): List<PillDomainIdentificationResponseDto> {
 
         val pillDomainResponse = pillManager
             .identifyPill(PillDomainIdentificationRequestDto(frontImage, backImage, fillShape, frontMarking, backMarking))


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
PillManager가 Clients 모듈의 PillIdentificationService를 호출해 AI 서버의 응답값을 본 서버 응답값으로 변환 해 응답.
## 스크린샷

## 주의사항

Closes #1 